### PR TITLE
Babylon repo is moving

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ See the example running [here](https://bogdan-lyashenko.github.io/js-code-to-svg
 
 ### Under the hood
 Main stages:
-- get AST from code, [Babylon](https://github.com/babel/babylon) parser is used (develops by Babel team)
+- get AST from code, [Babylon](https://github.com/babel/babel/tree/master/packages/babylon) parser is used (develops by Babel team)
 - convert AST to FlowTree, remove and combing nodes ([FlowTreeBuilder](src/builder/FlowTreeBuilder.js))
   - apply modifiers ([FlowTreeModifier](src/builder/FlowTreeModifier.js))
 - create SVG objects based on FlowTree ([SVGRender](src/render/svg/SVGRender.js))


### PR DESCRIPTION
Changing the link so the docs reference goes directly to the relevant documentation.

Looks like the 2 repos are in sync however, so the change is mainly to go directly to a useful readme.